### PR TITLE
add a 'confirm join' warning in the tournament view if a player has not joined a completed tournament

### DIFF
--- a/tournament/templates/tournament/snippets/confirm_join.html
+++ b/tournament/templates/tournament/snippets/confirm_join.html
@@ -1,0 +1,46 @@
+{% load tournament_extras %}
+
+{% for invite in invites %}
+{% if request.user.id == invite.send_to.id %}
+<div class="d-flex flex-row justify-content-between confirm-join-group alert alert-warning">
+  <div class="confirm-join-text">Confirm you participated in this tournament.</div>
+  <a href="{% url 'tournament:join_tournament' pk=invite.id %}" class="btn btn-primary confirm-join-btn">Confirm</a>
+</div>
+{% endif %}
+{% endfor %}
+
+<style type="text/css">
+
+  @media only screen and (max-width: 500px) {
+    .confirm-join-btn {
+      font-size: 12px;
+      margin-left: 8px;
+    }
+    .confirm-join-text {
+      vertical-align: middle;
+      text-align: left;
+      font-size: 12px;
+    }
+    .confirm-join-group {
+      margin-top: 16px;
+      text-align: center;
+      align-items: center;
+    }
+  }
+
+  @media only screen and (min-width: 501px) {
+    .confirm-join-btn {
+      margin-left: 8px;
+    }
+    .confirm-join-text {
+      vertical-align: middle;
+      text-align: left;
+      font-size: 12px;
+    }
+    .confirm-join-group {
+      margin-top: 16px;
+      text-align: center;
+      align-items: center;
+    }
+  }
+</style>

--- a/tournament/templates/tournament/snippets/joined_status_snippet.html
+++ b/tournament/templates/tournament/snippets/joined_status_snippet.html
@@ -114,6 +114,7 @@
       color: #292b2c;
       text-align: left;
     }
+
   }
 </style>
 

--- a/tournament/templates/tournament/tournament_view.html
+++ b/tournament/templates/tournament/tournament_view.html
@@ -51,6 +51,7 @@
         {% elif tournament.get_state_string == "ACTIVE" %}
         {% include 'tournament/snippets/tournament_players_active_state.html' with player_tournament_data=player_tournament_data allow_rebuys=allow_rebuys is_bounty_tournament=is_bounty_tournament %}
         {% else %}
+        {% include 'tournament/snippets/confirm_join.html' with players=players %}
         {% include 'tournament/snippets/tournament_players_completed_state.html' with players=players %}
         {% endif %}
 

--- a/tournament/views.py
+++ b/tournament/views.py
@@ -151,21 +151,22 @@ def join_tournament(request, *args, **kwargs):
 	try:
 		invite = TournamentInvite.objects.get(pk=kwargs['pk'])
 		if invite.send_to != user:
-			messages.error(request, "This invitation wasn't for you.")
+			messages.error(request, "That invitation wasn't for you.")
 			return redirect("home")
 
 		# Get the player and join the Tournament.
 		player = TournamentPlayer.objects.get_tournament_player_by_user_id(
-			tournament_id = invite.tournament,
-			user_id = invite.send_to
+			tournament_id = invite.tournament.id,
+			user_id = invite.send_to.id
 		)
 		TournamentPlayer.objects.join_tournament(
 			player = player
 		)
+		return redirect("tournament:tournament_view", pk=invite.tournament.id)
 
 	except Exception as e:
 		messages.error(request, e.args[0])
-	return redirect("tournament:tournament_view", pk=invite.tournament.id)
+	return redirect("home")
 
 """
 Uninvite a player from a tournament.


### PR DESCRIPTION
When backfilling tournament data, it's possible a player is added to a tournament even when that player has not actually joined the tournament.

This PR adds a warning to `tournament/views/tournament_view`. The warning tells the player they did not actually join the tournament and gives them an option to do so.