### PR TITLE
Rebuys, eliminations, and results are deleted when a tournament is de-activated.

### DIFF
--- a/tournament/templates/tournament/snippets/tournament_state_snippet.html
+++ b/tournament/templates/tournament/snippets/tournament_state_snippet.html
@@ -19,7 +19,7 @@
     {% if request.user == tournament.admin %}
       <div class="reopen-container mb-4">
         <p>Need to add/remove players or edit the Tournament Structure?</p>
-        <a class="btn btn-warning state-action-button" href="{% url 'tournament:undo_started' pk=tournament.id %}">de-activate</a>
+        <button class="btn btn-warning state-action-button" data-bs-toggle="modal" data-bs-target="#id_undo_activate_confirm">De-activate</button>
       </div>
       <a class="btn btn-primary state-action-button" href="{% url 'tournament:complete' pk=tournament.id %}" >Complete Tournament</a>
     {% endif %}
@@ -73,6 +73,33 @@
       </div>
       <div class="modal-footer" id="id_elim_model_button_container">
         <a href="{% url 'tournament:start' pk=tournament.id %}" class="btn btn-warning">Activate</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- De-activate confirm modal -->
+<div class="modal fade" id="id_undo_activate_confirm" tabindex="-1" aria-labelledby="de-activate Tournament Modal" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">
+          De-activate
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body d-flex flex-column">
+        <p>Are you sure?</p>
+        <p class="text-danger" style="font-weight: bold;">All the tournament data will be deleted. Including:</p>
+        <ol>
+          <li>Rebuys</li>
+          <li>Eliminations</li>
+          <li>Analytics</li>
+        </ol>
+        <p>Essentially you'll be resetting the tournament completely.</p>
+      </div>
+      <div class="modal-footer">
+        <a href="{% url 'tournament:undo_started' pk=tournament.id %}" class="btn btn-warning">De-activate</a>
       </div>
     </div>
   </div>

--- a/tournament/views.py
+++ b/tournament/views.py
@@ -138,9 +138,10 @@ def undo_started_at(request, *args, **kwargs):
 			error_message = "You are not the admin of this Tournament."
 		)
 
-		tournament = Tournament.objects.get_by_id(tournament_id)
-		tournament.started_at = None
-		tournament.save()
+		Tournament.objects.undo_start_tournament(
+			user = user,
+			tournament_id = tournament_id
+		)
 	except Exception as e:
 		messages.error(request, e.args[0])
 	return redirect("tournament:tournament_view", pk=tournament_id)


### PR DESCRIPTION
When you deactivate:
1. Delete rebuys
2. Delete eliminations
3. Delete TournamentPlayerResult data

Also when you initially try to deactivate, it will now show a warning modal telling you all the things that will be deleted.


https://user-images.githubusercontent.com/17446480/219519993-3661edde-c8d6-49f1-af48-d2fffb12b2ff.mov

