### PR TITLE
Email tournament completion data

### DIFF
--- a/tournament/models.py
+++ b/tournament/models.py
@@ -267,7 +267,6 @@ class TournamentManager(models.Manager):
 			players = TournamentPlayer.objects.get_tournament_players(
 				tournament_id = tournament.id
 			)
-			# for player in players:
 			emails = [player.user.email for player in players]
 			mail = EmailMessage(subject, message, settings.EMAIL_HOST_USER, emails)
 			mail.attach(msg)

--- a/tournament/templates/tournament/snippets/tournament_state_snippet.html
+++ b/tournament/templates/tournament/snippets/tournament_state_snippet.html
@@ -1,3 +1,11 @@
+<div class="overlay d-none" id="id_tournament_complete_spinner">
+  <div class="d-flex justify-content-center">
+    <div class="spinner-border" style="width: 70px; height: 70px;" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
+</div>
+
 <div class="tournament-state-container">
   <!-- COMPLETED -->
   {% if tournament_state.value == 2 %}
@@ -19,9 +27,9 @@
     {% if request.user == tournament.admin %}
       <div class="reopen-container mb-4">
         <p>Need to add/remove players or edit the Tournament Structure?</p>
-        <button class="btn btn-warning state-action-button" data-bs-toggle="modal" data-bs-target="#id_undo_activate_confirm">De-activate</button>
+        <button class="btn btn-warning state-action-button" data-bs-toggle="modal" data-bs-target="#id_undo_activate_confirm" id="id_deactivate_btn">De-activate</button>
       </div>
-      <a class="btn btn-primary state-action-button" href="{% url 'tournament:complete' pk=tournament.id %}" >Complete Tournament</a>
+      <a class="btn btn-primary state-action-button" id="id_complete_tournament_btn" href="{% url 'tournament:complete' pk=tournament.id %}" onclick="onClickCompleteTournament()">Complete Tournament</a>
     {% endif %}
 
   <!-- INACTIVE -->
@@ -85,7 +93,26 @@
   </div>
 </div>
 
+<script type="text/javascript">
+  function onClickCompleteTournament(){
+    document.getElementById("id_tournament_complete_spinner").classList.remove("d-none")
+    document.getElementById("id_complete_tournament_btn").classList.add("disabled")
+    document.getElementById("id_deactivate_btn").classList.add("disabled")
+  }
+</script>
+
 <style type="text/css">
+  .overlay {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+    top: 40%;
+    left: 0px;
+    opacity: 1;
+    filter: alpha(opacity=50);
+  }
+
   @media only screen and (max-width: 500px) {
     .reopen-container {
       padding-top: 8px;
@@ -117,10 +144,6 @@
   }
 
 </style>
-
-<script type="text/javascript">
-
-</script>
 
 
 

--- a/tournament/tests.py
+++ b/tournament/tests.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from django.core.exceptions import ValidationError
 from django.test import TransactionTestCase
+from unittest import mock
 
 from tournament.models import (
 	TournamentInvite,
@@ -1555,8 +1556,10 @@ class TournamentTestCase(TransactionTestCase):
 
 	"""
 	Verify cannot complete a Tournament if not the admin.
+	Using @mock to verify 'email_tournament_results' is called when a Tournament is successfully completed.
 	"""
-	def test_cannot_complete_tournament_if_not_admin(self):
+	@mock.patch.object(Tournament.objects, "email_tournament_results")
+	def test_cannot_complete_tournament_if_not_admin(self, mock):
 		# Build a structure made by cat
 		cat = User.objects.get_by_username("cat")
 		structure = self.build_structure(
@@ -1603,6 +1606,9 @@ class TournamentTestCase(TransactionTestCase):
 					tournament_id = tournament.id
 				)
 				self.assertTrue(tournament.completed_at != None)
+
+				# Verify the 'email_tournament_results' function is called when a Tournament is successfully completed.
+				mock.assert_called()
 			else:
 				with self.assertRaisesMessage(ValidationError, "You cannot update a Tournament if you're not the admin."):
 					Tournament.objects.complete_tournament(

--- a/tournament/util.py
+++ b/tournament/util.py
@@ -154,15 +154,15 @@ class SplitEliminationsData:
 
 def build_placement_string(placement):
 	if placement == 0:
-		return "1st"
+		return '1st'
 	elif placement == 1:
-		return "2nd"
+		return '2nd'
 	elif placement == 2:
-		return "3rd"
+		return '3rd'
 	elif placement == DID_NOT_PLACE_VALUE:
-		return "--"
+		return '--'
 	else:
-		return f"{placement + 1}th"
+		return f'{placement + 1}th'
 
 """
 Used in a template to apply styling based on placement.

--- a/tournament/views.py
+++ b/tournament/views.py
@@ -112,6 +112,7 @@ def start_tournament(request, *args, **kwargs):
 		tournament = Tournament.objects.start_tournament(user=user, tournament_id=tournament_id)
 	except Exception as e:
 		messages.error(request, e.args[0])
+		return redirect(request.META['HTTP_REFERER'])
 	return redirect("tournament:tournament_view", pk=tournament_id)
 
 @login_required
@@ -130,7 +131,7 @@ def complete_tournament(request, *args, **kwargs):
 		tournament = Tournament.objects.complete_tournament(user, tournament_id)
 	except Exception as e:
 		messages.error(request, e.args[0])
-	
+		return redirect(request.META['HTTP_REFERER'])
 	return redirect("tournament:tournament_view", pk=tournament_id)
 
 @login_required
@@ -152,6 +153,7 @@ def undo_completed_at(request, *args, **kwargs):
 		)
 	except Exception as e:
 		messages.error(request, e.args[0])
+		return redirect(request.META['HTTP_REFERER'])
 	return redirect("tournament:tournament_view", pk=tournament_id)
 
 @login_required
@@ -172,6 +174,7 @@ def undo_started_at(request, *args, **kwargs):
 		)
 	except Exception as e:
 		messages.error(request, e.args[0])
+		return redirect(request.META['HTTP_REFERER'])
 	return redirect("tournament:tournament_view", pk=tournament_id)
 
 """


### PR DESCRIPTION
When a tournament is completed, email a summary of the tournament.

The reason I'm doing this is to protect against accidental tournament data loss. At least each player will have a copy of the tournament details so the data won't be completely lost.

Note: Emailing is quite slow, so I added a loading spinner that shows when the "complete tournament" button is clicked.