### PR TITLE
Show net earnings in tournament group view

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ This is a notes section for me personally.
 1. TournamentGroup?
 1. Analaytics based on TournamentGroup
 	- Basically this would just extend the per-user analytics
-1. Create invite system for TournamentGroups. Just like with Touranemnts.
 1. Build the graphs so they can stand-alone and not require a view
 	1. Do fetch requests in whatever view uses the graph and fetch the data they need.
+1. Add footer
+1. Create invite system for TournamentGroups. Just like with Tournaments.
 1. Split winners
 	- Need to think about this.
 1. Setup bugsnag

--- a/root/templates/root/root.html
+++ b/root/templates/root/root.html
@@ -8,7 +8,7 @@
   This website is still in development.
 </div>
 
-{% include 'tournament_analytics/snippets/tournament_analytics.html' with tournament_totals=tournament_totals tournament_player_results=tournament_player_results rebuys_and_eliminations=rebuys_and_eliminations %}
+{% include 'tournament_analytics/snippets/tournament_analytics.html' with tournament_totals=tournament_totals tournament_player_results=tournament_player_results rebuys_and_eliminations=rebuys_and_eliminations tournament_groups=tournament_groups %}
 
 {% endblock content %}
 

--- a/root/views.py
+++ b/root/views.py
@@ -13,6 +13,7 @@ from tournament.models import (
 	TournamentSplitElimination,
 	TournamentPlayerResult
 )
+from tournament_group.models import TournamentGroup
 from tournament_analytics.models import TournamentTotals
 from tournament_analytics.util import something
 
@@ -65,6 +66,13 @@ def root_view(request):
 					color = f"rgb({color_list[0]}, {color_list[1]}, {color_list[2]})"
 					colors.append(color)
 				context['elimination_colors'] = colors
+
+			# Tournament Groups
+			tournament_groups = TournamentGroup.objects.get_tournament_groups(
+				user_id = request.user.id
+			)
+			if len(tournament_groups) > 0:
+				context['tournament_groups'] = tournament_groups
 
 			return render(request, "root/root.html", context=context)
 		else:

--- a/tournament_analytics/templates/tournament_analytics/snippets/tournament_analytics.html
+++ b/tournament_analytics/templates/tournament_analytics/snippets/tournament_analytics.html
@@ -11,31 +11,12 @@
   </div>
 </div>
 
-<!-- <div class="parent-chart-container d-none" id="id_charts_container">
-	<div class="first-charts-container">
-		<div class="net-earnings-vs-losses-container">
-			<canvas id="netEarningsVsLossesChartId"></canvas>
-		</div>
-		<div class="mb-4" id="id_chart_spacing">
-
-		</div>
-		<div class="eliminations-and-rebuys-container">
-			<canvas id="eliminationsAndRebuysChartId"></canvas>
-		</div>
-	</div>
-
-	<div class="mb-4" id="id_chart_spacing">
-
-	</div>
-
-	<div class="second-charts-container">
-		<div class="tournament-player-results-container">
-			<canvas id="tournamentPlayerResultsChartId"></canvas>
-		</div>
-	</div>
-</div> -->
-
 <div class="parent-chart-container d-none" id="id_charts_container">
+	<!-- Charts title -->
+	<div class="tournament-analytics" id="id_tournament_analytics_title">
+	  <h2>Your Tournament Analytics</h2>
+	</div>
+
 	<div class="first-charts-container" id="id_first_charts_container">
 		<div class="net-earnings-vs-losses-container">
 			<canvas id="netEarningsVsLossesChartId"></canvas>
@@ -57,6 +38,16 @@
 			<canvas id="eliminationsChartId"></canvas>
 		</div>
 	</div>
+
+	{% if tournament_groups %}
+	<!-- Tournament Groups-->
+	<div class="tournament-groups" id="id_tournament_groups_container">
+	  <h2>More Insights</h2>
+	  <hr>
+	  <p>View the analytics of the TournamentGroup's you're a part of.</p>
+	  {% include 'tournament_group/snippets/tournament_groups_list_snippet.html' with tournament_groups=tournament_groups %}
+	</div>
+	{% endif %}
 </div>
 
 <style type="text/css">
@@ -96,13 +87,14 @@
 		margin:auto;
 	}
 
-	@media only screen and (max-width: 500px) {
+	.tournament-analytics {
+		margin-top: 16px;
+		margin-bottom: 16px;
 	}
 
-	@media only screen and (min-width: 501px) {
-	}
-
-	@media only screen and (min-width: 700px) {
+	.tournament-groups {
+		margin-top: 24px;
+		margin-bottom: 16px;
 	}
 
 	@media only screen and (min-width: 1400px) {
@@ -173,6 +165,22 @@
 			left: net_earnings_vs_losses_container.offset().left
 		});
 
+		// align the title
+		$('.tournament-analytics').offset({
+			left: net_earnings_vs_losses_container.offset().left,
+		});
+		const netEarningsVsLossesWidth = $('.net-earnings-vs-losses-container').width()
+		const tournamentPlayerResultsWidth = $('.tournament-player-results-container').width()
+		const spaceBetween = $('.tournament-player-results-container').offset().left - ($('.net-earnings-vs-losses-container').offset().left + netEarningsVsLossesWidth)
+
+		document.getElementById("id_tournament_analytics_title").style.width = netEarningsVsLossesWidth + tournamentPlayerResultsWidth + spaceBetween + "px"
+
+		// align TournamentGroups section
+		$('.tournament-groups').offset({
+			left: net_earnings_vs_losses_container.offset().left,
+		});
+		document.getElementById("id_tournament_groups_container").style.width = netEarningsVsLossesWidth + tournamentPlayerResultsWidth + spaceBetween + "px"
+
 		var tournament_player_results_container = $('.tournament-player-results-container');
 		$('.eliminations-container').offset({
 			left: tournament_player_results_container.offset().left
@@ -201,6 +209,21 @@
 		$('.eliminations-and-rebuys-container').offset({
 			left: net_earnings_vs_losses_container.offset().left
 		});
+
+		// align the title
+		$('.tournament-analytics').offset({
+			left: net_earnings_vs_losses_container.offset().left
+		});
+		const netEarningsVsLossesWidth = $('.net-earnings-vs-losses-container').width()
+		const tournamentPlayerResultsWidth = $('.tournament-player-results-container').width()
+		const spaceBetween = $('.tournament-player-results-container').offset().left - ($('.net-earnings-vs-losses-container').offset().left + netEarningsVsLossesWidth)
+		document.getElementById("id_tournament_analytics_title").style.width = netEarningsVsLossesWidth + tournamentPlayerResultsWidth + spaceBetween + "px"
+
+		// align TournamentGroups section
+		$('.tournament-groups').offset({
+			left: net_earnings_vs_losses_container.offset().left
+		});
+		document.getElementById("id_tournament_groups_container").style.width = netEarningsVsLossesWidth + tournamentPlayerResultsWidth + spaceBetween + "px"
 
 		var tournament_player_results_container = $('.tournament-player-results-container');
 		$('.eliminations-container').offset({
@@ -238,7 +261,6 @@
 			var color = '{{color}}'
 			colors_data.push(color)
 		{% endfor %}
-
 	}
 
 	buildEliminationsData()
@@ -376,13 +398,13 @@
     	onClick: (e) => {
 	    },
 	    plugins: {
-				legend: {
-					position: 'top',
-				},
-				title: {
-					display: true,
-					text: 'Tournament Results'
-				},
+			legend: {
+				position: 'top',
+			},
+			title: {
+				display: true,
+				text: 'Tournament Results'
+			},
 	    	tooltip: {
 					callbacks: {
 						label: function(context) {
@@ -417,26 +439,26 @@
 	  plugins: [
 		  {
 		  	id: 'customHover',
-				afterEvent: (chart, event, opts) => {
-					const evt = event.event;
+			afterEvent: (chart, event, opts) => {
+				const evt = event.event;
 
-					if (evt.type !== 'mousemove') {
+				if (evt.type !== 'mousemove') {
 					return;
-					}
+				}
 
-					const [found, label] = findLabel(getLabelHitboxes(tournamentPlayerResultsChart.scales), evt);
+				const [found, label] = findLabel(getLabelHitboxes(tournamentPlayerResultsChart.scales), evt);
 
-					// Find the actual tournament title from the raw labels
-					if (found && tournamentPlayerResultsLabels.includes(label)) {
+				// Find the actual tournament title from the raw labels
+				if (found && tournamentPlayerResultsLabels.includes(label)) {
 					var labelIndex = tournamentPlayerResultsLabels.indexOf(label)
 					var tournamentTitle = rawTournamentPlayerResultLabels[labelIndex]
 					var date = tournamentPlayerResultCompletedAtDates[labelIndex]
-						showTooltip(chart, tournamentTitle, date)
-					} else {
-						hideTooltip(chart)
-					}
-				},
+					showTooltip(chart, tournamentTitle, date)
+				} else {
+					hideTooltip(chart)
+				}
 			},
+		  },
 	  ]
 	});
 

--- a/tournament_group/templates/tournament_group/charts/charts_common.html
+++ b/tournament_group/templates/tournament_group/charts/charts_common.html
@@ -1,0 +1,89 @@
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<script type="text/javascript">
+
+	// Need to track the mouse position to display title tooltips.
+	var mouseX = 0;
+	var mouseY = 0;
+
+	// Height / Width
+	const chartAspectRatio = .7;
+
+	// The point at which the chart size will become constant.
+	const windowWidthInflectionPoint = 700;
+
+	const chartPaddingSmall = 16;
+
+	function setChartContainerSize(element) {
+		const windowHeight = window.innerHeight;
+		const windowWidth = window.innerWidth;
+		if (windowWidth <= windowWidthInflectionPoint) {
+			const chartWidth = (windowWidth - (2 * chartPaddingSmall))
+			element.style.width = chartWidth + "px";
+			element.style.height = (chartWidth * chartAspectRatio) + "px"
+		} else {
+			// Set constant width of 700px - padding if the window is bigger than 700px
+			const chartWidth = (700 - (2 * chartPaddingSmall))
+			element.style.width = chartWidth + "px";
+			element.style.height = (chartWidth * chartAspectRatio) + "px"
+		}
+	}
+
+	function setInitialSizeOfChart(chart) {
+		const windowWidth = window.innerWidth;
+		if (windowWidth <= windowWidthInflectionPoint) {
+			const chartWidth = (windowWidth - (2 * chartPaddingSmall))
+			chart.canvas.parentNode.style.width = chartWidth + "px";
+			chart.canvas.parentNode.style.height = (chartWidth * chartAspectRatio) + "px"
+		} else {
+			// Set constant width of 700px - padding if the window is bigger than 700px
+			const chartWidth = (700 - (2 * chartPaddingSmall))
+			chart.canvas.parentNode.style.width = chartWidth + "px";
+			chart.canvas.parentNode.style.height = (chartWidth * chartAspectRatio) + "px"
+		}
+	}
+
+	function setSizeOfChart(chart) {
+		const windowWidth = window.innerWidth;
+		if (windowWidth <= windowWidthInflectionPoint) {
+			const chartWidth = (windowWidth - (2 * chartPaddingSmall))
+			chart.canvas.parentNode.style.width = chartWidth + "px";
+			chart.canvas.parentNode.style.height = (chartWidth * chartAspectRatio) + "px"
+		}
+	}
+
+	const findLabel = (labels, evt) => {
+	  let found = false;
+	  let res = null;
+
+	  labels.forEach(l => {
+		    l.labels.forEach(label => {
+		      if (evt.x > label.x && evt.x < label.x2 && evt.y > label.y && evt.y < label.y2) {
+		        res = label.label;
+		        found = true;
+		      }
+		    });
+		  });
+
+	  return [found, res];
+	};
+
+	const getLabelHitboxes = (scales) => (Object.values(scales).map((s) => ({
+		  scaleId: s.id,
+		  labels: s._labelItems.map((labelItem, i) => ({
+		    x: labelItem.options.translation[0] - s._labelSizes.widths[i] / 2,
+		    x2: labelItem.options.translation[0] + s._labelSizes.widths[i] / 2,
+		    y: labelItem.options.translation[1] - s._labelSizes.heights[i],
+		    y2: labelItem.options.translation[1] + s._labelSizes.heights[i],
+		    label: labelItem.label,
+		    index: i
+		  }))
+	})));
+
+	function mouseCoordinates(event){
+		mouseX = event.clientX + window.pageXOffset;
+		mouseY = event.clientY + window.pageYOffset;
+	}
+
+	document.onmousemove = mouseCoordinates;
+</script>

--- a/tournament_group/templates/tournament_group/charts/net_earnings_chart.html
+++ b/tournament_group/templates/tournament_group/charts/net_earnings_chart.html
@@ -1,0 +1,360 @@
+{% load tournament_extras %}
+
+<div class="container d-none" id="id_top_level_error">
+	<div class="row">
+		<div class="offset-md-1 col-md-10">
+			<div class="d-flex flex-column top-level-error">
+				<p class="text-danger" id="id_top_level_error_title"></p>
+				<p class="text-danger" id="id_top_level_error_description"></p>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="parent-chart-container" id="id_charts_container">
+	<div class="first-charts-container" id="id_first_charts_container">
+		<div class="net-earnings-container" id="id_net_earnings_container">
+			<div id="id_net_earnings_data_fetch_error" class="d-none d-flex flex-column">
+				<p class="text-danger" id="id_error_title"></p>
+				<p class="text-danger" id="id_error_description"></p>
+				<div class="d-flex flex-row">
+					<button class="btn btn-primary" onclick="retryFetchNetEarningsData()">Retry</button>
+				</div>
+			</div>
+			<canvas class="d-none" id="netEarningsChartId"></canvas>
+			<!-- Loading spinner to show before charts finished sizing and rendering -->
+			<div id="id_tournament_group_data_loading_spinner">
+			  <div class="net-earnings-spinner-container">
+			    <div class="spinner-border net-earnings-spinner-border" style="width: 70px; height: 70px;" role="status">
+			      <span class="visually-hidden">Loading...</span>
+			    </div>
+			  </div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<!-- Hidden field with fetch net earnings url -->
+<input class="d-none" id="id_hidden_fetch_net_earnings_url" value="{% url 'tournament_group:fetch_net_earnings_data' pk=tournament_group.id %}">
+
+<!-- Hidden field with fetch rbg colors -->
+<input class="d-none" id="id_hidden_fetch_rbg_colors_url" value="{% url 'tournament_group:fetch_rbg_colors' num_colors=users|length %}">
+
+<!-- Net earnings and losses -->
+<script>
+	var netEarningsChart = null
+	const netEarningsContext = document.getElementById('netEarningsChartId');
+	const usernames_data = [];
+	const short_usernames_data = [];
+	const net_earnings_data = []
+	const colors_data = []
+
+	window.onresize = function() {
+		setSizeOfChart(netEarningsChart)
+	}
+
+	function init() {
+		setChartContainerSize(document.getElementById("id_net_earnings_container"))
+		generateUserColorsData()
+	}
+
+	init()
+
+	function generateUserColorsData() {
+		const fetchRbgColorsUrl = document.getElementById("id_hidden_fetch_rbg_colors_url").value
+		fetch(fetchRbgColorsUrl)
+			.then((response) => {
+				return response.json()
+			})
+			.then((data) => {
+				if (data.error != null) {
+					onTopLevelError(data.error, data.message)
+				} else {
+					const json = data.rbg_colors
+					for (var key in json) {
+						var color = json[key]
+						colors_data.push(color)
+					}
+					onFetchColorsSuccess()
+				}
+			}).catch((error) => {
+				onTopLevelError("An unknown error occurred", "Data parsing issue.")
+			});
+	}
+
+	function onFetchColorsSuccess() {
+		fetchNetEarningsData()
+	}
+
+	function fetchNetEarningsData() {
+		const fetchNetEarningsDataUrl = document.getElementById("id_hidden_fetch_net_earnings_url").value
+		fetch(fetchNetEarningsDataUrl)
+			.then((response) => {
+				return response.json()
+			})
+			.then((data) => {
+				if (data.error != null) {
+					onNetEarningsDataFetchError(data.error, data.message)
+				} else {
+					const json = JSON.parse(data.net_earnings_data)
+					var counter = 1
+					for (var key in json) {
+						var username = json[key]['username']
+						usernames_data.push(username)
+
+						var short_username = "U" + counter
+						short_usernames_data.push(short_username)
+
+						var net_earnings = json[key]['net_earnings']
+						net_earnings_data.push(net_earnings)
+						counter += 1
+					}
+					buildNetEarningsChart()
+					onNetEarningsDataFetched()
+				}
+			}).catch((error) => {
+				onNetEarningsDataFetchError("An unknown error occurred", "Data parsing issue.")
+			});
+	}
+
+	function retryFetchNetEarningsData() {
+		document.getElementById("id_tournament_group_data_loading_spinner").classList.remove("d-none")
+		document.getElementById("netEarningsChartId").classList.add("d-none")
+		document.getElementById("id_net_earnings_data_fetch_error").classList.add("d-none")
+		document.getElementById("id_error_title").innerHTML = ""
+		document.getElementById("id_error_description").innerHTML = ""
+		fetchNetEarningsData()
+	}
+
+	function onTopLevelError(error_title, error_description) {
+		document.getElementById("id_top_level_error").classList.remove("d-none")
+		document.getElementById("id_top_level_error_title").innerHTML = error_title
+		document.getElementById("id_top_level_error_description").innerHTML = error_description
+
+		onNetEarningsDataFetchError("Error", "Something went wrong.")
+	}
+
+	function onNetEarningsDataFetched() {
+		document.getElementById("id_tournament_group_data_loading_spinner").classList.add("d-none")
+		document.getElementById("netEarningsChartId").classList.remove("d-none")
+	}
+
+	function onNetEarningsDataFetchError(error_title, error_description) {
+		document.getElementById("id_net_earnings_data_fetch_error").classList.remove("d-none")
+		document.getElementById("id_tournament_group_data_loading_spinner").classList.add("d-none")
+		document.getElementById("id_error_title").innerHTML = error_title
+		document.getElementById("id_error_description").innerHTML = error_description
+	}
+
+	function buildNetEarningsChart() {
+		const netEarningsData = {
+			labels: short_usernames_data,
+			datasets: [
+				{
+					label: 'Net Earnings',
+					data: net_earnings_data,
+					backgroundColor: colors_data,
+				},
+			]
+		};
+
+		netEarningsChart = new Chart(netEarningsContext, {
+		  type: 'bar',
+		  data: netEarningsData,
+		  options: {
+		  	maintainAspectRatio: false,
+		  	responsive: true,
+		  	plugins: {
+				legend: {
+					display: false,
+				},
+				title: {
+					display: true,
+					text: 'Net Earnings for Players'
+				},
+				tooltip: {
+					callbacks: {
+						label: function(context) {
+							let label = context.dataset.label || '';
+
+							if (label) {
+								label += ': ';
+							}
+							if (context.parsed.y !== null) {
+								label += new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(context.parsed.y);
+							}
+							return label;
+						},
+						title: function(context) {
+							let title = context[0].label
+							let index = short_usernames_data.indexOf(title)
+							return usernames_data[index]
+						}
+					},
+				}
+			},
+			scales: {
+				y: {
+					ticks: {
+						callback: function(value, index, ticks) {
+							return '$' + value;
+						}
+					},
+				},
+			},
+		  },
+		  plugins: [
+			  {
+			  	id: 'customHover',
+				afterEvent: (chart, event, opts) => {
+					const evt = event.event;
+
+					if (evt.type !== 'mousemove') {
+						return;
+					}
+
+					const [found, label] = findLabel(getLabelHitboxes(netEarningsChart.scales), evt);
+
+					// Find the actual username from the raw labels
+					if (found && short_usernames_data.includes(label)) {
+						var labelIndex = short_usernames_data.indexOf(label)
+						var username = usernames_data[labelIndex]
+						showNetEarningsTooltip(chart, username)
+					} else {
+						hideNetEarningsTooltip(chart)
+					}
+				},
+			  },
+		  	],
+		});
+
+		setInitialSizeOfChart(netEarningsChart)
+	}
+
+
+	function hideNetEarningsTooltip(context) {
+	  let tooltipEl = document.getElementById('chartjs-tooltip');
+
+	  // Create element on first render
+	  if (!tooltipEl) {
+	    tooltipEl = document.createElement('div');
+	    tooltipEl.id = 'chartjs-tooltip';
+	    tooltipEl.innerHTML = '<table></table>';
+	    document.body.appendChild(tooltipEl);
+	  }
+	  tooltipEl.classList.add("d-none")
+	}
+
+	function showNetEarningsTooltip(context, label){
+		// Tooltip Element
+	    let tooltipEl = document.getElementById('chartjs-tooltip');
+
+	    // Create element on first render
+	    if (!tooltipEl) {
+	        tooltipEl = document.createElement('div');
+	        tooltipEl.id = 'chartjs-tooltip';
+	        tooltipEl.innerHTML = '<table></table>';
+	        document.body.appendChild(tooltipEl);
+	    }
+	    tooltipEl.classList.remove("d-none")
+
+	    const tooltipModel = context.tooltip;
+
+	    // Set caret Position
+	    tooltipEl.classList.remove('above', 'below', 'no-transform');
+	    if (tooltipModel.yAlign) {
+	        tooltipEl.classList.add(tooltipModel.yAlign);
+	    } else {
+	        tooltipEl.classList.add('no-transform');
+	    }
+
+	    // Set Text
+		const titleLines = [label]
+
+	    let innerHtml = '<thead>';
+
+	    titleLines.forEach(function(title) {
+	        innerHtml += '<tr><th>' + title + '</th></tr>';
+	    });
+	    innerHtml += '</thead><tbody>';
+
+	    innerHtml += '</tbody>';
+
+	    let tableRoot = tooltipEl.querySelector('table');
+	    tableRoot.innerHTML = innerHtml;
+
+	    const position = context.canvas.getBoundingClientRect();
+
+	    const bodyFont = Chart.helpers.toFont(tooltipModel.options.bodyFont);
+
+	    // Display, position, and set styles for font
+	    tooltipEl.style.opacity = .75;
+	    tooltipEl.style.position = 'absolute';
+	    tooltipEl.style.left = mouseX + 'px';
+	    tooltipEl.style.top = mouseY + 'px';
+	    tooltipEl.style.font = bodyFont.string;
+	    tooltipEl.style.padding = '10px';
+	    tooltipEl.style.backgroundColor = '#000';
+	    tooltipEl.style.color = '#fff';
+	    tooltipEl.style.borderRadius = '8px';
+	    tooltipEl.style.pointerEvents = 'none';
+	}
+
+</script>
+
+<style type="text/css">
+
+	.parent-chart-container {
+		margin-bottom: 24px;
+	}
+
+	.net-earnings-container {
+		margin: auto;
+		border-radius: 8px;
+		border: 1px solid #c3c3c3;
+		padding: 16px;
+	}
+
+	.first-charts-container {
+		margin:auto;
+	}
+
+	@media only screen and (min-width: 1400px) {
+		.first-charts-container {
+			display: flex;
+			direction: column;
+		}
+	}
+
+	#id_tournament_group_data_loading_spinner {
+		height: 100%;
+		position: relative;
+	}
+
+	.net-earnings-spinner-container {
+		margin: auto;
+		position: absolute;
+		left: 50%;
+		top: 50%;
+	}
+	.net-earnings-spinner-border {
+		position: absolute;
+		left: -35px;
+		top: -35px;
+	}
+</style>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tournament_group/templates/tournament_group/charts/net_earnings_chart.html
+++ b/tournament_group/templates/tournament_group/charts/net_earnings_chart.html
@@ -37,7 +37,7 @@
 <!-- Hidden field with fetch net earnings url -->
 <input class="d-none" id="id_hidden_fetch_net_earnings_url" value="{% url 'tournament_group:fetch_net_earnings_data' pk=tournament_group.id %}">
 
-<!-- Hidden field with fetch rbg colors -->
+<!-- Hidden field with fetch rbg colors url -->
 <input class="d-none" id="id_hidden_fetch_rbg_colors_url" value="{% url 'tournament_group:fetch_rbg_colors' num_colors=users|length %}">
 
 <!-- Net earnings and losses -->

--- a/tournament_group/templates/tournament_group/tournament_group_view.html
+++ b/tournament_group/templates/tournament_group/tournament_group_view.html
@@ -9,34 +9,49 @@
 <div class="container">
   <div class="row">
     <div class="offset-md-1 col-md-10">
-      <div class="d-flex flex-row justify-content-between align-items-center mb-4">
+      <div class="d-flex flex-row justify-content-between tournament-group-section-content-container">
         <h2 class="tournament-group-title">{{tournament_group.title}}</h2>
         {% if request.user == tournament_group.admin %}
-        <a href="{% url 'tournament_group:update' pk=tournament_group.id %}" class="btn btn-outline-primary">Edit</a>
+          <a href="{% url 'tournament_group:update' pk=tournament_group.id %}" class="btn btn-outline-primary">Edit</a>
         {% endif %}
       </div>
+    </div>
+  </div>
+</div>
 
+{% include 'tournament_group/charts/charts_common.html' %}
+{% include 'tournament_group/charts/net_earnings_chart.html' %}
+
+<div class="container">
+  <div class="row">
+    <div class="offset-md-1 col-md-10">
       <!-- Users -->
       <h5>Users</h5>
       <hr>
-      <div class="tournament-group-section-container">
+      <div class="tournament-group-section-content-container">
         <!-- Display the users who have already been added -->
         {% if users %}
           {% include 'tournament_group/snippets/display_user_list_snippet.html' with users=users %}
         {% endif %}
       </div>
+    </div>
+  </div>
+</div>
 
+
+<div class="container">
+  <div class="row">
+    <div class="offset-md-1 col-md-10">
       <!-- Tournaments -->
       <h5>Tournaments</h5>
       <hr>
-      <div class="tournament-group-section-container">
+      <div class="tournament-group-section-content-container">
         {% if tournaments %}
         <div class="mt-4">
           <!-- Display the tournaments that have already been added -->
           {% include 'tournament_group/snippets/tournament_list_snippet.html' with tournaments=tournaments %}
         </div>
         {% endif %}
-
       </div>
     </div>
   </div>
@@ -56,10 +71,11 @@
       text-align: left;
       font-size: 16px;
       margin-right: 16px;
+      margin-top: auto;
     }
-    .tournament-group-section-container {
-      margin-bottom: 16px;
+    .tournament-group-section-content-container {
       font-size: 12px;
+      margin-bottom: 16px;
     }
   }
 
@@ -71,12 +87,12 @@
       text-align: left;
       font-size: 24px;
       margin-right: 16px;
+      margin-top: auto;
     }
-    .tournament-group-section-container {
+    .tournament-group-section-content-container {
       padding-left: 16px;
       padding-right: 16px;
-      padding-bottom: 16px;
-      margin-bottom: 16px;
+      margin-bottom: 24px;
       font-size: 16px;
     }
 

--- a/tournament_group/urls.py
+++ b/tournament_group/urls.py
@@ -3,6 +3,8 @@ from django.urls import include, path
 from tournament_group.views import (
 	add_tournament_to_group,
 	add_user_to_group,
+	fetch_rbg_colors,
+	fetch_tournament_group_net_earnings_data,
 	remove_tournament_from_group,
 	remove_user_from_group,
 	tournament_group_create_view,
@@ -17,6 +19,8 @@ urlpatterns = [
     path('add_user_to_group/<int:user_id>/<int:tournament_group_id>/', add_user_to_group, name="add_user_to_group"),
     path('add_tourament_to_group/<int:tournament_id>/<int:tournament_group_id>/', add_tournament_to_group, name="add_tournament_to_group"),
     path('remove_tournament_from_group/<int:tournament_id>/<int:tournament_group_id>/', remove_tournament_from_group, name="remove_tournament_from_group"),
+    path('fetch_net_earnings_data/<int:pk>/', fetch_tournament_group_net_earnings_data, name="fetch_net_earnings_data"),
+    path('fetch_rbg_colors/<int:num_colors>/', fetch_rbg_colors, name="fetch_rbg_colors"),
     path('create/', tournament_group_create_view, name="create"),
     path('remove_user_from_group/<int:user_id>/<int:tournament_group_id>/', remove_user_from_group, name="remove_user_from_group"),
     path('update/<int:pk>/', tournament_group_update_view, name="update"),

--- a/tournament_group/util.py
+++ b/tournament_group/util.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+import json
+
+@dataclass
+class TournamentGroupNetEarnings:
+	username: str
+	net_earnings: float
+
+def build_json_from_net_earnings_data(list_of_group_net_earnings):
+	data_list = []
+	for item in list_of_group_net_earnings:
+		data = {
+			'username': item.username,
+			'net_earnings': f"{item.net_earnings}"
+		}
+		data_list.append(data)
+	return json.dumps(data_list)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tournament_group/views.py
+++ b/tournament_group/views.py
@@ -121,23 +121,6 @@ def view_tournament_group(request, *args, **kwargs):
 		context['tournaments'] = tournaments
 
 		context['edit_mode'] = False
-
-		# Build the TournamentGroupNetEarnings data
-		# TODO make this async with its own URL for the view and do an http fetch
-		net_earnings_data = TournamentGroup.objects.build_group_net_earnings_data(
-			group = tournament_group
-		)
-		context['net_earnings_data'] = net_earnings_data
-
-		# For each user generate a random color.
-		# colors = []
-		# for x in net_earnings_data:
-		# 	color_list = list(random.choices(range(256), k=3))
-		# 	color = f"rgb({color_list[0]}, {color_list[1]}, {color_list[2]})"
-		# 	colors.append(color)
-		# context['user_colors'] = colors
-		# END
-
 	except Exception as e:
 		messages.error(request, e.args[0])
 	return render(request=request, template_name='tournament_group/tournament_group_view.html', context=context)

--- a/tournament_group/views.py
+++ b/tournament_group/views.py
@@ -1,11 +1,15 @@
 from django.core.exceptions import ValidationError
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
+from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render, redirect
+import random
+import json
 
 from tournament.models import Tournament, TournamentPlayer
 from tournament_group.forms import CreateTournamentGroupForm
 from tournament_group.models import TournamentGroup
+from tournament_group.util import build_json_from_net_earnings_data
 from user.models import User
 
 @login_required
@@ -118,9 +122,66 @@ def view_tournament_group(request, *args, **kwargs):
 
 		context['edit_mode'] = False
 
+		# Build the TournamentGroupNetEarnings data
+		# TODO make this async with its own URL for the view and do an http fetch
+		net_earnings_data = TournamentGroup.objects.build_group_net_earnings_data(
+			group = tournament_group
+		)
+		context['net_earnings_data'] = net_earnings_data
+
+		# For each user generate a random color.
+		# colors = []
+		# for x in net_earnings_data:
+		# 	color_list = list(random.choices(range(256), k=3))
+		# 	color = f"rgb({color_list[0]}, {color_list[1]}, {color_list[2]})"
+		# 	colors.append(color)
+		# context['user_colors'] = colors
+		# END
+
 	except Exception as e:
 		messages.error(request, e.args[0])
 	return render(request=request, template_name='tournament_group/tournament_group_view.html', context=context)
+
+@login_required
+def fetch_tournament_group_net_earnings_data(request, *args, **kwargs):
+	context = {}
+	try:
+		pk = kwargs['pk']
+		tournament_group = TournamentGroup.objects.get_by_id(pk)
+		if tournament_group == None:
+			raise ValidationError("Our records indicate that TournamentGroup does not exist.")
+
+		net_earnings_data = TournamentGroup.objects.build_group_net_earnings_data(
+			group = tournament_group
+		)
+		# context['net_earnings_data'] = net_earnings_data
+		context['net_earnings_data'] = build_json_from_net_earnings_data(net_earnings_data)
+	except Exception as e:
+		error = {
+			'error': "Unable to retrieve net earnings data.",
+			'message': f"{e.args[0]}"
+		}
+		return JsonResponse(error, status=200)
+	return JsonResponse(context, status=200)
+
+@login_required
+def fetch_rbg_colors(request, *args, **kwargs):
+	context = {}
+	try:
+		num_colors = kwargs['num_colors']
+		colors = {}
+		for x in range(0, int(num_colors)):
+			color_list = list(random.choices(range(256), k=3))
+			color = f"rgb({color_list[0]}, {color_list[1]}, {color_list[2]})"
+			colors[f"{x}"] = color
+		context['rbg_colors'] = colors
+	except Exception as e:
+		error = {
+			'error': "Unable to retrieve colors for graphs.",
+			'message': f"{e.args[0]}"
+		}
+		return JsonResponse(error, status=200)
+	return JsonResponse(context, status=200)
 
 """
 HTMX request for adding a user to a TournamentGroup.
@@ -132,11 +193,11 @@ def add_user_to_group(request, *args, **kwargs):
 		tournament_group_id = kwargs['tournament_group_id']
 
 		user = User.objects.get_by_id(user_id)
-		tourmament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
+		tournament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
 		
 		TournamentGroup.objects.add_users_to_group(
 			admin = request.user,
-			group = tourmament_group,
+			group = tournament_group,
 			users = [user]
 		)
 	except Exception as e:
@@ -153,11 +214,11 @@ def remove_user_from_group(request, *args, **kwargs):
 		tournament_group_id = kwargs['tournament_group_id']
 
 		user = User.objects.get_by_id(user_id)
-		tourmament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
+		tournament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
 		
 		TournamentGroup.objects.remove_user_from_group(
 			admin = request.user,
-			group = tourmament_group,
+			group = tournament_group,
 			user = user
 		)
 	except Exception as e:
@@ -174,11 +235,11 @@ def add_tournament_to_group(request, *args, **kwargs):
 		tournament_group_id = kwargs['tournament_group_id']
 
 		tournament = Tournament.objects.get_by_id(tournament_id)
-		tourmament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
+		tournament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
 		
 		TournamentGroup.objects.add_tournaments_to_group(
 			admin = request.user,
-			group = tourmament_group,
+			group = tournament_group,
 			tournaments = [tournament]
 		)
 	except Exception as e:
@@ -196,11 +257,11 @@ def remove_tournament_from_group(request, *args, **kwargs):
 		tournament_group_id = kwargs['tournament_group_id']
 
 		tournament = Tournament.objects.get_by_id(tournament_id)
-		tourmament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
+		tournament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
 		
 		TournamentGroup.objects.remove_tournament_from_group(
 			admin = request.user,
-			group = tourmament_group,
+			group = tournament_group,
 			tournament = tournament
 		)
 	except Exception as e:
@@ -216,11 +277,11 @@ def update_tournament_group_title(request, *args, **kwargs):
 		title = kwargs['title']
 		tournament_group_id = kwargs['tournament_group_id']
 
-		tourmament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
+		tournament_group = TournamentGroup.objects.get_by_id(tournament_group_id)
 		
 		TournamentGroup.objects.update_tournament_group_title(
 			admin = request.user,
-			group = tourmament_group,
+			group = tournament_group,
 			title = title
 		)
 	except Exception as e:


### PR DESCRIPTION
1. Show net earnings in the TournamentGroup view.
2.  Update `root.html` to have a "More Insights" section that links to the TournamentGroup's they are part of.

![Screenshot 2023-02-28 at 7 38 03 AM](https://user-images.githubusercontent.com/17446480/221902413-ca289f3a-5285-496e-bf86-9cbe4ba9f216.png)
